### PR TITLE
FEAT: Docker integration

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,33 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  topos:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          # based on branch push tag latest for main with commit sha
+          tags: yassinsiouda/topos:latest, yassinsiouda/topos:main-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:lts-alpine as dev
+
+WORKDIR /app
+COPY ./ /app
+
+# install dependencies
+RUN yarn install
+
+# Run dev
+ENTRYPOINT [ "yarn", "run", "dev" ]
+
+FROM node:lts-alpine as build
+
+WORKDIR /app
+
+# copy node modules from dev stage
+COPY --from=dev /app/ /app/
+
+# build
+RUN yarn run build
+
+FROM nginx:alpine as prod
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -52,4 +52,17 @@ The `tauri` version is only here to quickstart future developments but nothing 
 `docker compose --profile prod up`
 
 ### Build and run the dev image
-`docker compose --profile dev up`
+
+**First installation**
+First you need to map node_modules to your local machine for your ide intellisense to work properly
+```bash
+docker compose --profile dev up -d
+docker cp topos-dev:/app/node_modules .
+docker compose --profile dev down
+```
+
+**Then**
+```bash
+docker compose --profile dev up
+```
+

--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ To build a standalone browser application using [Tauri](https://tauri.app/), you
 - `yarn tauri dev`
 
 The `tauri` version is only here to quickstart future developments but nothing has been done yet.
+
+## Docker
+
+### Run the application
+`docker run -p 8001:80 yassinsiouda/topos:latest`
+
+### Build and run the prod image
+`docker compose --profile prod up`
+
+### Build and run the dev image
+`docker compose --profile dev up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.7'
+services:
+  topos-dev:
+    container_name: topos-dev
+    profiles: ["dev"]
+    build: 
+      context: .
+      target: "dev"
+    ports:
+      - "8000:8000"
+  topos-prod:
+    container_name: topos-prod
+    profiles: ["prod"]
+    build: 
+      context: .
+      target: "prod"
+    ports:
+      - "8001:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,16 @@ services:
     build: 
       context: .
       target: "dev"
+    volumes:
+      - ./src:/app/src
+      - ./fonts:/app/fonts
+      - ./img:/app/img
+      - ./package.json:/app/package.json
+      - ./postcss.config.js:/app/postcss.config.js
+      - ./tailwind.config.js:/app/tailwind.config.js
+      - ./tsconfig.json:/app/tsconfig.json
+      - ./vite.config.js:/app/vite.config.js
+      - ./yarn.lock:/app/yarn.lock
     ports:
       - "8000:8000"
   topos-prod:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
Docker integration 
- to simply selfhost topo
- for local develpment
- a ci to build a docker image when new commits on main branch 